### PR TITLE
fix(tokens): 恢复主按钮文字对比度 —— button-primary-dimmed 改用已有莫兰迪浅色前景色

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -297,7 +297,7 @@ ${labelStack(p, false)}
 ${borderStack(p, false)}
   --dsw-alias-button-primary-fill: ${aL};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${aL}, black 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(aL, 85)};
+  --dsw-alias-button-primary-dimmed: ${bgL};
   --dsw-alias-button-tool-bar-fill: ${sfL};
   --dsw-alias-button-tool-bar-hover: ${mix(txL, 95)};
   --dsw-alias-button-floating-fill: ${sfL};
@@ -371,7 +371,7 @@ ${labelStack(p, true)}
 ${borderStack(p, true)}
   --dsw-alias-button-primary-fill: ${aD};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${aD}, white 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(aD, 82)};
+  --dsw-alias-button-primary-dimmed: ${bgD};
   --dsw-alias-button-tool-bar-fill: ${sfD};
   --dsw-alias-button-tool-bar-hover: ${mix(txD, 92)};
   --dsw-alias-button-floating-fill: ${sfD};
@@ -437,7 +437,7 @@ ${sel} {${bloomTokens(p, dark)}${sharedDswTokens(p, dark)}
   --dsw-alias-brand-text: ${bg};
   --dsw-alias-button-primary-fill: ${a};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${a}, ${dark ? "white" : "black"} 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(a, dark ? 82 : 85)};
+  --dsw-alias-button-primary-dimmed: ${bg};
   --dsw-alias-button-info-fill: ${mix(a, dark ? 86 : 90)};
   --dsw-alias-button-info-hover: ${mix(a, dark ? 78 : 84)};
   --dsw-alias-button-ghost-active-fill: ${mix(a, dark ? 88 : 92)};

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -254,7 +254,7 @@ ${labelStack(p, false)}
 ${borderStack(p, false)}
   --dsw-alias-button-primary-fill: ${aL};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${aL}, black 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(aL, 85)};
+  --dsw-alias-button-primary-dimmed: ${bgL};
   --dsw-alias-button-tool-bar-fill: ${sfL};
   --dsw-alias-button-tool-bar-hover: ${mix(txL, 95)};
   --dsw-alias-button-floating-fill: ${sfL};
@@ -330,7 +330,7 @@ ${labelStack(p, true)}
 ${borderStack(p, true)}
   --dsw-alias-button-primary-fill: ${aD};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${aD}, white 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(aD, 82)};
+  --dsw-alias-button-primary-dimmed: ${bgD};
   --dsw-alias-button-tool-bar-fill: ${sfD};
   --dsw-alias-button-tool-bar-hover: ${mix(txD, 92)};
   --dsw-alias-button-floating-fill: ${sfD};
@@ -403,7 +403,7 @@ ${sel} {${bloomTokens(p, dark)}${sharedDswTokens(p, dark)}
   --dsw-alias-brand-text: ${bg};
   --dsw-alias-button-primary-fill: ${a};
   --dsw-alias-button-primary-hover: color-mix(in oklch, ${a}, ${dark ? 'white' : 'black'} 8%);
-  --dsw-alias-button-primary-dimmed: ${mix(a, dark ? 82 : 85)};
+  --dsw-alias-button-primary-dimmed: ${bg};
   --dsw-alias-button-info-fill: ${mix(a, dark ? 86 : 90)};
   --dsw-alias-button-info-hover: ${mix(a, dark ? 78 : 84)};
   --dsw-alias-button-ghost-active-fill: ${mix(a, dark ? 88 : 92)};


### PR DESCRIPTION
## 问题

`--dsw-alias-button-primary-dimmed` 是 DSH 的 alias token，其语义是**叠在 `--dsw-alias-button-primary-fill`（实色主按钮填充）之上的可读文字色**。第三方组件（如 `@opendsh/dsh-plugin-scheduled-tasks`）正是用这对 token 渲染主按钮与选中 tab：

```css
.dshst-btn-primary {
  background: var(--dsw-alias-button-primary-fill);
  color:      var(--dsw-alias-button-primary-dimmed);
}
```

Bloom 之前把 `button-primary-dimmed` 定义成 accent 的透明淡化（亮色 `mix(accent, 85%)`、暗色 `mix(accent, 82%)`），而 `button-primary-fill` 是**实色 accent**。于是合成后变成「同一色相、~15–18% 透明度的 accent 叠在实色 accent 上」≈ 底色本身，对比度趋近 0，按钮文字几乎不可见（issue #16 截图：列表页/新建表单页那几颗只见纯色圆角块、看不到字的蓝色主按钮）。

## 修复

恢复 `button-primary-dimmed` 的 DSH 语义：让它指向**主题自身**在 accent 主按钮上已经使用的那个莫兰迪浅色前景色（`--dsw-alias-label-primary-foreground` = 各变体的 `bgL`/`bgD`）。没有新增任何取色，直接复用 UI 里已有的颜色；且 `accent × bg` 正是本仓 `contrast-guard` 已校验 ≥4.5 的那一对（WCAG 比值对称）。

```diff
- --dsw-alias-button-primary-dimmed: ${mix(aL, 85)};
+ --dsw-alias-button-primary-dimmed: ${bgL};
```

三处（`mistLight` 骨架、`mistDark`、`variantBlock`）同步修改；产品侧已是全部明暗变体同一语义。同受影响、一并解决：`.dshst-tab-active`（选中 tab 用同一对 token）。

## 验证

- `npm run build` → 重生成 `lib/client.js`，产物仍 classic-safe。
- `npm run check` → 8 类自检 + `contrast-guard` **18/18 组配色全部 ≥4.5:1**。
- 手动复算所有变体 `text(bg) on fill(accent)` 的 WCAG 比值（全部通过 AA）：

| 变体 | 亮色 | 暗色 |
|---|---|---|
| mist | 5.28:1 | 5.96:1 |
| cinnabar | 4.87:1 | — |
| petal | 4.55:1 | 6.07:1 |
| ripple | 4.84:1 | — |
| sage | 4.53:1 | — |
| stone | 5.48:1 | — |
| lapis | — | 7.31:1 |
| amber | — | 7.65:1 |
| aurora | 5.10:1 | — |

> 注：本次只影响「按 DSH 约定消费 `button-primary-fill` × `button-primary-dimmed` 这对 token」的第三方主按钮；Bloom 自身组件用的 accent 主按钮文字走的是 `label-primary-foreground`，本就正确，未改动。

修复已在本地部署到运行中的 Web profile 并确认生成 CSS 值正确；由于涉及运行环境，配套截图已附于 issue #16。

Closes #16
