### PR TITLE
fix(updater): respect host-managed and prerelease DSH versions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1371,23 +1371,71 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
   }
   var dshLatestVersion = null;
   var dshCheckPromise = null;
-  var DSH_CACHE_KEY = "bloom-dsh-check";
+  var DSH_CACHE_KEY = "bloom-dsh-check-v2";
   var DSH_CACHE_TTL_MS = 6 * 60 * 60 * 1e3;
-  function readDshCurrentRev() {
+  function parseSemver(value) {
+    const match = String(value ?? "").trim().match(
+      /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+    );
+    if (!match) return null;
+    return {
+      core: [Number(match[1]), Number(match[2]), Number(match[3])],
+      prerelease: match[4] ? match[4].split(".") : []
+    };
+  }
+  function isSemver(value) {
+    return parseSemver(value) !== null;
+  }
+  function normalizeSemver(value) {
+    if (!isSemver(value)) return null;
+    return String(value).trim().replace(/^v/, "");
+  }
+  function readDshRuntimeInfo() {
     try {
-      const rev = window.__DSH_BOOT__?.rev;
-      return typeof rev === "string" ? rev.slice(0, 7) : null;
+      const hostWindow = window;
+      const bridge = hostWindow.__DSH_LOCAL__ || {};
+      const boot = hostWindow.__DSH_BOOT__ || {};
+      const dataVersion = document.documentElement?.dataset?.dshRuntimeVersion;
+      const currentVersion = [bridge.runtimeVersion, dataVersion, boot.version, boot.rev].map(normalizeSemver).find(Boolean) || null;
+      const buildRev = typeof boot.rev === "string" && /^[0-9a-f]{7,40}$/i.test(boot.rev) ? boot.rev.slice(0, 7) : null;
+      const updateManagedBy = typeof bridge.updateManagedBy === "string" && bridge.updateManagedBy.trim() ? bridge.updateManagedBy.trim() : null;
+      return {
+        currentVersion,
+        buildRev,
+        updateManagedBy,
+        updateMode: typeof bridge.updateMode === "string" ? bridge.updateMode : null,
+        requestUpdateCheck: typeof bridge.requestUpdateCheck === "function" ? bridge.requestUpdateCheck.bind(bridge) : null
+      };
     } catch {
-      return null;
+      return {
+        currentVersion: null,
+        buildRev: null,
+        updateManagedBy: null,
+        updateMode: null,
+        requestUpdateCheck: null
+      };
     }
   }
+  function selectDshDistTag(distTags, currentVersion) {
+    const parsed = parseSemver(currentVersion);
+    const prereleaseChannel = parsed?.prerelease[0];
+    if (prereleaseChannel && typeof distTags[prereleaseChannel] === "string") return prereleaseChannel;
+    if (prereleaseChannel && typeof distTags.next === "string") return "next";
+    return typeof distTags.latest === "string" ? "latest" : null;
+  }
   async function checkDshLatest(force = false) {
+    const runtime = readDshRuntimeInfo();
+    if (runtime.updateManagedBy) {
+      dshLatestVersion = null;
+      renderDshUpdate();
+      return;
+    }
     if (!force) {
       try {
         const raw = sessionStorage.getItem(DSH_CACHE_KEY);
         if (raw) {
           const cached = JSON.parse(raw);
-          if (cached?.at && Date.now() - cached.at < DSH_CACHE_TTL_MS && cached.latest) {
+          if (cached?.at && Date.now() - cached.at < DSH_CACHE_TTL_MS && cached.latest && cached.currentVersion === runtime.currentVersion) {
             dshLatestVersion = cached.latest;
             renderDshUpdate();
             return;
@@ -1399,12 +1447,22 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
     if (dshCheckPromise) return dshCheckPromise;
     dshCheckPromise = (async () => {
       try {
-        const r = await fetch("https://registry.npmjs.org/@deepseek-ai/dsh/latest", { cache: "no-store" });
+        const r = await fetch(
+          "https://registry.npmjs.org/-/package/@deepseek-ai%2Fdsh/dist-tags",
+          { cache: "no-store" }
+        );
         if (r.ok) {
-          const d = await r.json();
-          dshLatestVersion = d && d.version || null;
+          const distTags = await r.json();
+          const tag = selectDshDistTag(distTags, runtime.currentVersion);
+          const selected = tag ? distTags?.[tag] : null;
+          dshLatestVersion = typeof selected === "string" ? selected : null;
           try {
-            sessionStorage.setItem(DSH_CACHE_KEY, JSON.stringify({ at: Date.now(), latest: dshLatestVersion }));
+            sessionStorage.setItem(DSH_CACHE_KEY, JSON.stringify({
+              at: Date.now(),
+              latest: dshLatestVersion,
+              currentVersion: runtime.currentVersion,
+              tag
+            }));
           } catch {
           }
         } else {
@@ -1420,26 +1478,72 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
     return dshCheckPromise;
   }
   function renderDshUpdate() {
+    const root = document.querySelector(".dsh-bloom-dsh-update");
     const curEl = document.querySelector("[data-dsh-current]");
     const latEl = document.querySelector("[data-dsh-latest]");
     const stEl = document.querySelector("[data-dsh-state]");
     const hintEl = document.querySelector("[data-dsh-hint]");
-    if (!curEl || !latEl || !stEl || !hintEl) return;
-    const cur = readDshCurrentRev() || "?";
+    if (!root || !curEl || !latEl || !stEl || !hintEl) return;
+    const runtime = readDshRuntimeInfo();
+    const cur = runtime.currentVersion || runtime.buildRev || "?";
     curEl.textContent = cur;
-    if (dshLatestVersion == null) {
-      latEl.textContent = "点击 ↻ 检查";
-      stEl.removeAttribute("data-state");
-      stEl.textContent = "";
-    } else {
-      latEl.textContent = dshLatestVersion;
-      stEl.textContent = "✓ 已是最新";
-      stEl.setAttribute("data-state", "latest");
-    }
-    hintEl.hidden = true;
-    hintEl.textContent = "";
     const btnRefresh = document.querySelector('[data-act="refresh"]');
     const btnCopy = document.querySelector('[data-act="copy"]');
+    if (runtime.updateManagedBy) {
+      root.dataset.updateManagedBy = runtime.updateManagedBy;
+      latEl.textContent = "由桌面端检查";
+      stEl.textContent = `${runtime.updateManagedBy} 管理更新`;
+      stEl.setAttribute("data-state", "managed");
+      hintEl.hidden = true;
+      hintEl.textContent = "";
+      if (btnRefresh) {
+        btnRefresh.hidden = false;
+        btnRefresh.disabled = runtime.requestUpdateCheck == null;
+        btnRefresh.textContent = "检查更新";
+        btnRefresh.title = runtime.requestUpdateCheck ? `由 ${runtime.updateManagedBy} 检查官方更新` : `请在 ${runtime.updateManagedBy} 中检查更新`;
+      }
+      if (btnCopy) {
+        btnCopy.hidden = true;
+        btnCopy.disabled = true;
+      }
+    } else {
+      delete root.dataset.updateManagedBy;
+      if (btnRefresh) {
+        btnRefresh.hidden = false;
+        btnRefresh.disabled = false;
+        btnRefresh.textContent = "↻ 检查";
+        btnRefresh.title = "重新检查 DSH 最新版";
+      }
+      if (btnCopy) {
+        btnCopy.hidden = false;
+        btnCopy.disabled = dshLatestVersion == null;
+        btnCopy.title = dshLatestVersion ? `复制升级命令到剪贴板：npm i -g @deepseek-ai/dsh@${dshLatestVersion}` : "检查到可用版本后复制精确升级命令";
+      }
+      if (dshLatestVersion == null) {
+        latEl.textContent = "点击 ↻ 检查";
+        stEl.removeAttribute("data-state");
+        stEl.textContent = "";
+      } else if (!runtime.currentVersion) {
+        latEl.textContent = dshLatestVersion;
+        stEl.textContent = "版本未知";
+        stEl.setAttribute("data-state", "err");
+      } else {
+        latEl.textContent = dshLatestVersion;
+        const comparison = cmpVersion(dshLatestVersion, runtime.currentVersion);
+        if (comparison > 0) {
+          stEl.textContent = "↑ 可更新";
+          stEl.setAttribute("data-state", "update");
+        } else if (comparison < 0) {
+          stEl.textContent = "当前版本较新";
+          stEl.setAttribute("data-state", "ahead");
+        } else {
+          stEl.textContent = "✓ 已是最新";
+          stEl.setAttribute("data-state", "latest");
+        }
+      }
+      hintEl.hidden = true;
+      hintEl.textContent = "";
+    }
     if (btnRefresh && !btnRefresh.dataset.bloomBound) {
       btnRefresh.dataset.bloomBound = "1";
       btnRefresh.addEventListener("click", async (ev) => {
@@ -1449,6 +1553,14 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
         btnRefresh.disabled = true;
         stEl.textContent = "检查中…";
         stEl.removeAttribute("data-state");
+        const liveRuntime = readDshRuntimeInfo();
+        if (liveRuntime.updateManagedBy) {
+          liveRuntime.requestUpdateCheck?.();
+          btnRefresh.disabled = liveRuntime.requestUpdateCheck == null;
+          btnRefresh.textContent = "检查更新";
+          renderDshUpdate();
+          return;
+        }
         try {
           await checkDshLatest(true);
         } finally {
@@ -1461,7 +1573,13 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
       btnCopy.dataset.bloomBound = "1";
       btnCopy.addEventListener("click", async (ev) => {
         ev.stopPropagation();
-        const cmd = "npm i -g @deepseek-ai/dsh@latest";
+        const liveRuntime = readDshRuntimeInfo();
+        if (liveRuntime.updateManagedBy) {
+          liveRuntime.requestUpdateCheck?.();
+          return;
+        }
+        if (!dshLatestVersion) return;
+        const cmd = `npm i -g @deepseek-ai/dsh@${dshLatestVersion}`;
         let ok = false;
         try {
           if (navigator.clipboard?.writeText) {
@@ -1500,12 +1618,29 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
     }
   }
   function cmpVersion(a, b) {
-    const pa = String(a).replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
-    const pb = String(b).replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
+    const pa = parseSemver(a);
+    const pb = parseSemver(b);
+    if (!pa || !pb) return 0;
     for (let i = 0; i < 3; i++) {
-      const na = pa[i] || 0, nb = pb[i] || 0;
+      const na = pa.core[i], nb = pb.core[i];
       if (na > nb) return 1;
       if (na < nb) return -1;
+    }
+    if (pa.prerelease.length === 0 && pb.prerelease.length === 0) return 0;
+    if (pa.prerelease.length === 0) return 1;
+    if (pb.prerelease.length === 0) return -1;
+    const length = Math.max(pa.prerelease.length, pb.prerelease.length);
+    for (let i = 0; i < length; i++) {
+      const left = pa.prerelease[i];
+      const right = pb.prerelease[i];
+      if (left == null) return -1;
+      if (right == null) return 1;
+      if (left === right) continue;
+      const leftNumeric = /^\d+$/.test(left);
+      const rightNumeric = /^\d+$/.test(right);
+      if (leftNumeric && rightNumeric) return Number(left) > Number(right) ? 1 : -1;
+      if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+      return left > right ? 1 : -1;
     }
     return 0;
   }
@@ -1728,6 +1863,11 @@ body[data-ds-dark-theme] [class*="_tableScroll"] tbody tr:nth-child(even) td {
   background: color-mix(in oklch, oklch(45% 0.13 150), transparent 88%);
   color: oklch(45% 0.13 150);
 }
+.dsh-bloom-dsh-state[data-state="managed"],
+.dsh-bloom-dsh-state[data-state="ahead"] {
+  background: color-mix(in oklch, var(--dsw-alias-brand-primary, #4a90e2), transparent 88%);
+  color: var(--dsw-alias-brand-primary, #4a90e2);
+}
 .dsh-bloom-dsh-state[data-state="err"] {
   background: color-mix(in oklch, oklch(48% 0.17 28), transparent 88%);
   color: oklch(48% 0.17 28);
@@ -1890,7 +2030,7 @@ body[data-ds-dark-theme] .dsh-bloom-dsh-hint {
       </div>
       <div class="dsh-bloom-dsh-actions">
         <button type="button" class="dsh-bloom-dsh-btn" data-act="refresh" title="重新检查 DSH 最新版">↻ 检查</button>
-        <button type="button" class="dsh-bloom-dsh-btn dsh-bloom-dsh-btn--primary" data-act="copy" title="复制升级命令到剪贴板：npm i -g @deepseek-ai/dsh@latest">复制命令</button>
+        <button type="button" class="dsh-bloom-dsh-btn dsh-bloom-dsh-btn--primary" data-act="copy" title="检查到可用版本后复制精确升级命令">复制命令</button>
       </div>
       <div class="dsh-bloom-dsh-hint" data-dsh-hint hidden></div>
     </div>

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
     "package": "npm run build && npm pack",
     "desktop:link": "node scripts/desktop-profile.mjs link",
     "desktop:production": "node scripts/desktop-profile.mjs production",
-    "check": "node scripts/check.mjs && contrast-guard",
+    "check": "node scripts/check.mjs && contrast-guard && node --test scripts/version.test.mjs",
     "check:contrast": "contrast-guard",
     "prepublishOnly": "node scripts/sync-version.mjs && npm run build && npm run check",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",
+    "test:version": "node --test scripts/version.test.mjs",
     "preflight": "node scripts/preflight.mjs",
     "stats": "node scripts/stats-table.mjs"
   },

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+// version.ts belongs to the browser bundle, so compile a tiny test-only ESM copy
+// without adding a runtime dependency or changing Bloom's production bundle.
+import { build } from 'esbuild'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const sourceURL = new URL('../src/version.ts', import.meta.url)
+const testDirectory = await mkdtemp(join(tmpdir(), 'bloom-version-test-'))
+const outputPath = join(testDirectory, 'version.mjs')
+await build({
+  entryPoints: [fileURLToPath(sourceURL)],
+  outfile: outputPath,
+  bundle: true,
+  platform: 'browser',
+  format: 'esm',
+  target: 'es2020',
+})
+const { cmpVersion, selectDshDistTag } = await import(`${pathToFileURL(outputPath).href}?t=${Date.now()}`)
+
+test.after(async () => {
+  await rm(testDirectory, { recursive: true, force: true })
+})
+
+test('compares prerelease versions using SemVer precedence', () => {
+  assert.equal(cmpVersion('0.1.2-alpha.4', '0.1.2-alpha.3'), 1)
+  assert.equal(cmpVersion('0.1.2-alpha.4', '0.1.2-alpha.4'), 0)
+  assert.equal(cmpVersion('0.1.2', '0.1.2-rc.2'), 1)
+  assert.equal(cmpVersion('0.1.2-alpha.1', '0.1.2-rc.1'), -1)
+})
+
+test('selects the current prerelease channel instead of latest', () => {
+  const tags = {
+    latest: '0.1.1-rc.2',
+    next: '0.1.1-rc.2',
+    alpha: '0.1.2-alpha.4',
+  }
+  assert.equal(selectDshDistTag(tags, '0.1.2-alpha.3'), 'alpha')
+  assert.equal(selectDshDistTag(tags, '0.1.1-rc.2'), 'next')
+  assert.equal(selectDshDistTag(tags, '0.1.2'), 'latest')
+})

--- a/src/css/switcher.ts
+++ b/src/css/switcher.ts
@@ -207,6 +207,11 @@ export const SWITCHER_CSS = `
   background: color-mix(in oklch, oklch(45% 0.13 150), transparent 88%);
   color: oklch(45% 0.13 150);
 }
+.dsh-bloom-dsh-state[data-state="managed"],
+.dsh-bloom-dsh-state[data-state="ahead"] {
+  background: color-mix(in oklch, var(--dsw-alias-brand-primary, #4a90e2), transparent 88%);
+  color: var(--dsw-alias-brand-primary, #4a90e2);
+}
 .dsh-bloom-dsh-state[data-state="err"] {
   background: color-mix(in oklch, oklch(48% 0.17 28), transparent 88%);
   color: oklch(48% 0.17 28);

--- a/src/switcher.ts
+++ b/src/switcher.ts
@@ -80,7 +80,7 @@ export function buildSwitcherHTML(currentVariant) {
       </div>
       <div class="dsh-bloom-dsh-actions">
         <button type="button" class="dsh-bloom-dsh-btn" data-act="refresh" title="重新检查 DSH 最新版">↻ 检查</button>
-        <button type="button" class="dsh-bloom-dsh-btn dsh-bloom-dsh-btn--primary" data-act="copy" title="复制升级命令到剪贴板：npm i -g @deepseek-ai/dsh@latest">复制命令</button>
+        <button type="button" class="dsh-bloom-dsh-btn dsh-bloom-dsh-btn--primary" data-act="copy" title="检查到可用版本后复制精确升级命令">复制命令</button>
       </div>
       <div class="dsh-bloom-dsh-hint" data-dsh-hint hidden></div>
     </div>

--- a/src/version.ts
+++ b/src/version.ts
@@ -27,31 +27,128 @@ export async function checkUpdate() {
   refreshUpdateBadge()
 }
 
-/* ── DSH 升级检查（看 npm latest + 本地 __DSH_BOOT__.rev）── */
+/* ── DSH 升级检查（宿主管理器优先；否则按当前预发布通道查 npm dist-tag）── */
 export let dshLatestVersion: string | null = null
 
 export let dshCheckPromise: Promise<void> | null = null
 
-export const DSH_CACHE_KEY = 'bloom-dsh-check'
+export const DSH_CACHE_KEY = 'bloom-dsh-check-v2'
 
 export const DSH_CACHE_TTL_MS = 6 * 60 * 60 * 1000 // 6h
 
-/** 从 window.__DSH_BOOT__.rev 读当前 DSH 构建 hash（截短 7 字符）。 */
-export function readDshCurrentRev(): string | null {
-  try {
-    const rev = (window as any).__DSH_BOOT__?.rev
-    return typeof rev === 'string' ? rev.slice(0, 7) : null
-  } catch { return null }
+type DshLocalBridge = {
+  runtimeVersion?: string
+  updateManagedBy?: string
+  updateMode?: string
+  requestUpdateCheck?: () => void
 }
 
-/** 从 npm registry 拉 @deepseek-ai/dsh latest（缓存 6h，避免每次开下拉都打网络）。 */
+export type DshRuntimeInfo = {
+  currentVersion: string | null
+  buildRev: string | null
+  updateManagedBy: string | null
+  updateMode: string | null
+  requestUpdateCheck: (() => void) | null
+}
+
+type ParsedSemver = {
+  core: [number, number, number]
+  prerelease: string[]
+}
+
+function parseSemver(value: unknown): ParsedSemver | null {
+  const match = String(value ?? '').trim().match(
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/,
+  )
+  if (!match) return null
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+export function isSemver(value: unknown): boolean {
+  return parseSemver(value) !== null
+}
+
+function normalizeSemver(value: unknown): string | null {
+  if (!isSemver(value)) return null
+  return String(value).trim().replace(/^v/, '')
+}
+
+/**
+ * 读取宿主运行时信息。桌面壳提供的语义化版本优先；提交 hash 只作为构建号展示，
+ * 永远不参与版本大小比较。
+ */
+export function readDshRuntimeInfo(): DshRuntimeInfo {
+  try {
+    const hostWindow = window as any
+    const bridge = (hostWindow.__DSH_LOCAL__ || {}) as DshLocalBridge
+    const boot = hostWindow.__DSH_BOOT__ || {}
+    const dataVersion = document.documentElement?.dataset?.dshRuntimeVersion
+    const currentVersion = [bridge.runtimeVersion, dataVersion, boot.version, boot.rev]
+      .map(normalizeSemver)
+      .find(Boolean) || null
+    const buildRev = typeof boot.rev === 'string' && /^[0-9a-f]{7,40}$/i.test(boot.rev)
+      ? boot.rev.slice(0, 7)
+      : null
+    const updateManagedBy = typeof bridge.updateManagedBy === 'string' && bridge.updateManagedBy.trim()
+      ? bridge.updateManagedBy.trim()
+      : null
+    return {
+      currentVersion,
+      buildRev,
+      updateManagedBy,
+      updateMode: typeof bridge.updateMode === 'string' ? bridge.updateMode : null,
+      requestUpdateCheck: typeof bridge.requestUpdateCheck === 'function'
+        ? bridge.requestUpdateCheck.bind(bridge)
+        : null,
+    }
+  } catch {
+    return {
+      currentVersion: null,
+      buildRev: null,
+      updateManagedBy: null,
+      updateMode: null,
+      requestUpdateCheck: null,
+    }
+  }
+}
+
+/** 保留旧导出：它现在只代表构建 hash，不再冒充当前版本。 */
+export function readDshCurrentRev(): string | null {
+  return readDshRuntimeInfo().buildRev
+}
+
+/** 按当前版本选择 npm dist-tag，避免 alpha 被 latest/rc 误判为可降级。 */
+export function selectDshDistTag(
+  distTags: Record<string, unknown>,
+  currentVersion: string | null,
+): string | null {
+  const parsed = parseSemver(currentVersion)
+  const prereleaseChannel = parsed?.prerelease[0]
+  if (prereleaseChannel && typeof distTags[prereleaseChannel] === 'string') return prereleaseChannel
+  if (prereleaseChannel && typeof distTags.next === 'string') return 'next'
+  return typeof distTags.latest === 'string' ? 'latest' : null
+}
+
+/** 从 npm registry 拉匹配当前通道的 DSH 版本（缓存 6h）。 */
 export async function checkDshLatest(force = false): Promise<void> {
+  const runtime = readDshRuntimeInfo()
+  if (runtime.updateManagedBy) {
+    dshLatestVersion = null
+    renderDshUpdate()
+    return
+  }
   if (!force) {
     try {
       const raw = sessionStorage.getItem(DSH_CACHE_KEY)
       if (raw) {
         const cached = JSON.parse(raw)
-        if (cached?.at && Date.now() - cached.at < DSH_CACHE_TTL_MS && cached.latest) {
+        if (cached?.at
+          && Date.now() - cached.at < DSH_CACHE_TTL_MS
+          && cached.latest
+          && cached.currentVersion === runtime.currentVersion) {
           dshLatestVersion = cached.latest
           renderDshUpdate()
           return
@@ -62,11 +159,23 @@ export async function checkDshLatest(force = false): Promise<void> {
   if (dshCheckPromise) return dshCheckPromise
   dshCheckPromise = (async () => {
     try {
-      const r = await fetch('https://registry.npmjs.org/@deepseek-ai/dsh/latest', { cache: 'no-store' })
+      const r = await fetch(
+        'https://registry.npmjs.org/-/package/@deepseek-ai%2Fdsh/dist-tags',
+        { cache: 'no-store' },
+      )
       if (r.ok) {
-        const d = await r.json()
-        dshLatestVersion = (d && d.version) || null
-        try { sessionStorage.setItem(DSH_CACHE_KEY, JSON.stringify({ at: Date.now(), latest: dshLatestVersion })) } catch {}
+        const distTags = await r.json()
+        const tag = selectDshDistTag(distTags, runtime.currentVersion)
+        const selected = tag ? distTags?.[tag] : null
+        dshLatestVersion = typeof selected === 'string' ? selected : null
+        try {
+          sessionStorage.setItem(DSH_CACHE_KEY, JSON.stringify({
+            at: Date.now(),
+            latest: dshLatestVersion,
+            currentVersion: runtime.currentVersion,
+            tag,
+          }))
+        } catch {}
       } else {
         dshLatestVersion = null
       }
@@ -80,31 +189,83 @@ export async function checkDshLatest(force = false): Promise<void> {
   return dshCheckPromise
 }
 
-/** 把 DSH 当前 rev + npm latest 渲染到下拉区块；绑按钮事件。 */
+/** 把宿主版本和对应更新通道渲染到下拉区块；绑按钮事件。 */
 export function renderDshUpdate() {
+  const root = document.querySelector<HTMLElement>('.dsh-bloom-dsh-update')
   const curEl = document.querySelector<HTMLElement>('[data-dsh-current]')
   const latEl = document.querySelector<HTMLElement>('[data-dsh-latest]')
   const stEl = document.querySelector<HTMLElement>('[data-dsh-state]')
   const hintEl = document.querySelector<HTMLElement>('[data-dsh-hint]')
-  if (!curEl || !latEl || !stEl || !hintEl) return
+  if (!root || !curEl || !latEl || !stEl || !hintEl) return
 
-  const cur = readDshCurrentRev() || '?'
+  const runtime = readDshRuntimeInfo()
+  const cur = runtime.currentVersion || runtime.buildRev || '?'
   curEl.textContent = cur
-
-  if (dshLatestVersion == null) {
-    latEl.textContent = '点击 ↻ 检查'
-    stEl.removeAttribute('data-state')
-    stEl.textContent = ''
-  } else {
-    latEl.textContent = dshLatestVersion
-    stEl.textContent = '✓ 已是最新'
-    stEl.setAttribute('data-state', 'latest')
-  }
-  hintEl.hidden = true
-  hintEl.textContent = ''
 
   const btnRefresh = document.querySelector<HTMLButtonElement>('[data-act="refresh"]')
   const btnCopy = document.querySelector<HTMLButtonElement>('[data-act="copy"]')
+
+  if (runtime.updateManagedBy) {
+    root.dataset.updateManagedBy = runtime.updateManagedBy
+    latEl.textContent = '由桌面端检查'
+    stEl.textContent = `${runtime.updateManagedBy} 管理更新`
+    stEl.setAttribute('data-state', 'managed')
+    hintEl.hidden = true
+    hintEl.textContent = ''
+    if (btnRefresh) {
+      btnRefresh.hidden = false
+      btnRefresh.disabled = runtime.requestUpdateCheck == null
+      btnRefresh.textContent = '检查更新'
+      btnRefresh.title = runtime.requestUpdateCheck
+        ? `由 ${runtime.updateManagedBy} 检查官方更新`
+        : `请在 ${runtime.updateManagedBy} 中检查更新`
+    }
+    if (btnCopy) {
+      btnCopy.hidden = true
+      btnCopy.disabled = true
+    }
+  } else {
+    delete root.dataset.updateManagedBy
+    if (btnRefresh) {
+      btnRefresh.hidden = false
+      btnRefresh.disabled = false
+      btnRefresh.textContent = '↻ 检查'
+      btnRefresh.title = '重新检查 DSH 最新版'
+    }
+    if (btnCopy) {
+      btnCopy.hidden = false
+      btnCopy.disabled = dshLatestVersion == null
+      btnCopy.title = dshLatestVersion
+        ? `复制升级命令到剪贴板：npm i -g @deepseek-ai/dsh@${dshLatestVersion}`
+        : '检查到可用版本后复制精确升级命令'
+    }
+
+    if (dshLatestVersion == null) {
+      latEl.textContent = '点击 ↻ 检查'
+      stEl.removeAttribute('data-state')
+      stEl.textContent = ''
+    } else if (!runtime.currentVersion) {
+      latEl.textContent = dshLatestVersion
+      stEl.textContent = '版本未知'
+      stEl.setAttribute('data-state', 'err')
+    } else {
+      latEl.textContent = dshLatestVersion
+      const comparison = cmpVersion(dshLatestVersion, runtime.currentVersion)
+      if (comparison > 0) {
+        stEl.textContent = '↑ 可更新'
+        stEl.setAttribute('data-state', 'update')
+      } else if (comparison < 0) {
+        stEl.textContent = '当前版本较新'
+        stEl.setAttribute('data-state', 'ahead')
+      } else {
+        stEl.textContent = '✓ 已是最新'
+        stEl.setAttribute('data-state', 'latest')
+      }
+    }
+    hintEl.hidden = true
+    hintEl.textContent = ''
+  }
+
   if (btnRefresh && !btnRefresh.dataset.bloomBound) {
     btnRefresh.dataset.bloomBound = '1'
     btnRefresh.addEventListener('click', async (ev) => {
@@ -117,6 +278,14 @@ export function renderDshUpdate() {
       btnRefresh.disabled = true
       stEl.textContent = '检查中…'
       stEl.removeAttribute('data-state')
+      const liveRuntime = readDshRuntimeInfo()
+      if (liveRuntime.updateManagedBy) {
+        liveRuntime.requestUpdateCheck?.()
+        btnRefresh.disabled = liveRuntime.requestUpdateCheck == null
+        btnRefresh.textContent = '检查更新'
+        renderDshUpdate()
+        return
+      }
       try { await checkDshLatest(true) } finally {
         btnRefresh.disabled = false
         btnRefresh.textContent = label
@@ -127,7 +296,13 @@ export function renderDshUpdate() {
     btnCopy.dataset.bloomBound = '1'
     btnCopy.addEventListener('click', async (ev) => {
       ev.stopPropagation()
-      const cmd = 'npm i -g @deepseek-ai/dsh@latest'
+      const liveRuntime = readDshRuntimeInfo()
+      if (liveRuntime.updateManagedBy) {
+        liveRuntime.requestUpdateCheck?.()
+        return
+      }
+      if (!dshLatestVersion) return
+      const cmd = `npm i -g @deepseek-ai/dsh@${dshLatestVersion}`
       let ok = false
       try {
         if (navigator.clipboard?.writeText) {
@@ -165,14 +340,31 @@ export function renderDshUpdate() {
   }
 }
 
-/** 简单版本大小比较：a>b→1, a<b→-1, 相等→0（处理 leading v / 缺段）。 */
+/** SemVer 比较：正确处理 alpha / beta / rc；无效输入视为相等。 */
 export function cmpVersion(a, b) {
-  const pa = String(a).replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0)
-  const pb = String(b).replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0)
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return 0
   for (let i = 0; i < 3; i++) {
-    const na = pa[i] || 0, nb = pb[i] || 0
+    const na = pa.core[i], nb = pb.core[i]
     if (na > nb) return 1
     if (na < nb) return -1
+  }
+  if (pa.prerelease.length === 0 && pb.prerelease.length === 0) return 0
+  if (pa.prerelease.length === 0) return 1
+  if (pb.prerelease.length === 0) return -1
+  const length = Math.max(pa.prerelease.length, pb.prerelease.length)
+  for (let i = 0; i < length; i++) {
+    const left = pa.prerelease[i]
+    const right = pb.prerelease[i]
+    if (left == null) return -1
+    if (right == null) return 1
+    if (left === right) continue
+    const leftNumeric = /^\d+$/.test(left)
+    const rightNumeric = /^\d+$/.test(right)
+    if (leftNumeric && rightNumeric) return Number(left) > Number(right) ? 1 : -1
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1
+    return left > right ? 1 : -1
   }
   return 0
 }


### PR DESCRIPTION
## Problem

Bloom currently treats `window.__DSH_BOOT__.rev` as the installed DSH version, although source builds expose a commit hash there. It also checks only npm's `latest` tag and always renders “已是最新” after a successful response.

That breaks prerelease installations: for example, an installed `0.1.2-alpha.4` can be shown as a hash while npm `latest` still points to `0.1.1-rc.2`. The copied `npm i -g ...@latest` command can then install the wrong channel or downgrade a host-managed runtime.

## Changes

- Prefer semantic runtime metadata supplied through an optional `window.__DSH_LOCAL__` host contract.
- Keep `__DSH_BOOT__.rev` as a display-only build hash; never compare it as SemVer.
- Delegate update checks to an external desktop manager and hide the global npm command when `updateManagedBy` is present.
- Otherwise fetch npm dist-tags and follow the current prerelease channel (`alpha`, `next`, or `latest`).
- Compare prerelease identifiers with SemVer precedence and render update/latest/ahead/unknown states accurately.
- Copy an exact discovered version instead of `@latest` for standalone npm installs.
- Add regression tests for SemVer precedence and dist-tag selection; include them in `npm run check`.

## Optional host contract

```js
window.__DSH_LOCAL__ = Object.freeze({
  runtimeVersion: '0.1.2-alpha.4',
  updateManagedBy: 'DSH Local',
  updateMode: 'native',
  requestUpdateCheck() { /* fixed native action */ },
})
```

Hosts that do not provide this object keep the standalone npm flow.

## Verification

- `npm run build`
- `npm run check`
- `npm run test:version`
- `node --check lib/client.js && node --check lib/index.js`
- Manually verified with Bloom 0.9.0 on a DSH Local-managed `0.1.2-alpha.4` runtime: the semantic version is shown and the check button delegates to the native updater without exposing a downgrade command.